### PR TITLE
아코디언 컴포넌트 기능 개선

### DIFF
--- a/js/accordion.js
+++ b/js/accordion.js
@@ -10,15 +10,16 @@ jui.defineUI("ui.accordion", [ "jquery", "util.base" ], function($, _) {
         var activeIndex = 0;
 
         var $title = null,
-            $content = null;
+            $contents = null;
 
         function showTitle(index) {
             $title.each(function(i) {
                 if(index == i) {
                     $(this).addClass("active");
-                    $content.insertAfter(this).show();
+                    $(this).next().show();
                 } else {
                     $(this).removeClass("active");
+                    $(this).next().hide();
                 }
             });
         }
@@ -28,7 +29,7 @@ jui.defineUI("ui.accordion", [ "jquery", "util.base" ], function($, _) {
                 self.addEvent(this, "click", function(e) {
                     if($(this).hasClass("active") && self.options.autoFold) {
                         $(this).removeClass("active");
-                        $content.hide();
+                        $(this).next().hide();
                         self.emit("fold", [ i, e ] );
                     } else {
                         showTitle(i);
@@ -42,16 +43,16 @@ jui.defineUI("ui.accordion", [ "jquery", "util.base" ], function($, _) {
             var opts = this.options;
 
             $title = $(this.root).find(".title");
-            $content = $(this.root).find(".content");
+            $contents = $(this.root).find(".content");
 
             if(_.typeCheck("integer", opts.index)) {
                 showTitle(opts.index);
             } else {
-                $content.hide();
+                $contents.hide();
             }
 
             setTitleEvent(this);
-        }
+        };
 
         /**
          * @method activeIndex


### PR DESCRIPTION
#438 에 대한 수정내용입니다.

기존 아코디언 컴포넌트가 div.content를 재활용하도록 되어 있어 다음과 같이 개별 아코디언 탭 뒤에 div.content를 추가해서 직관적으로 아코디언 탭과 콘텐츠를 추가할 수 있도록 개선하였습니다.

기존 샘플 코드 변경 부분(HTML)
```html
<div id="accordion_1" class="accordion">
    <div class="title active">
        Group Item #1 <i class="icon-arrow3"></i>
    </div>
    <div class="content">
        First Accordion
    </div>
    <div class="title">
        Group Item #2 <i class="icon-arrow1"></i>
    </div>
    <div class="content">
        Second Accordion
    </div>
    <div class="title">
        Group Item #3 <i class="icon-arrow1"></i>
    </div>
    <div class="content">
        Three Accordion
    </div>
</div>
```