### PR TITLE
창 높이가 변경되는 경우에도 modal resize

### DIFF
--- a/js/modal.js
+++ b/js/modal.js
@@ -1,22 +1,24 @@
 jui.defineUI("ui.modal", [ "jquery", "util.base" ], function($, _) {
 
 	var win_width = 0;
-	
+    var win_height = 0;
+
 	_.resize(function() {
-		if(win_width == $(window).width()) return; 
-		
+		if(win_width == $(window).width() && win_height == $(window).height()) return;
+
 		var call_list = jui.get("ui.modal");
 		for(var i = 0; i < call_list.length; i++) {
 			var ui_list = call_list[i];
-			
+
 			for(var j = 0; j < ui_list.length; j++) {
 				if(ui_list[j].type == "show") {
 					ui_list[j].resize();
 				}
 			}
 		}
-		
+
 		win_width = $(window).width();
+        win_height = $(window).height();
 	}, 300);
 
     /**
@@ -33,16 +35,16 @@ jui.defineUI("ui.modal", [ "jquery", "util.base" ], function($, _) {
 		var $modal = {}, $clone = null;
 		var uiObj = null, uiTarget = null;
 		var z_index = 5000;
-		
+
 		function setPrevStatus(self) {
-			uiObj = { 
+			uiObj = {
 				"position": $(self.root).css("position"),
 				"left": $(self.root).css("left"),
 				"top": $(self.root).css("top"),
 				"z-index": $(self.root).css("z-index"),
 				"display": $(self.root).css("display")
 			};
-			
+
 			uiTarget = {
 				"position": $(self.options.target).css("position")
 			};
@@ -59,14 +61,14 @@ jui.defineUI("ui.modal", [ "jquery", "util.base" ], function($, _) {
 				}
 			}
 		}
-		
+
 		function getModalInfo(self) {
 			var target = self.options.target,
 				hTarget = (target == "body") ? window : target,
 				pos = (target == "body") ? "fixed" : "absolute",
 				tPos = getInnerModalPosition(target),
                 sLeft = $(target).scrollLeft();
-			
+
 			var x = (($(hTarget).width() / 2) - ($(self.root).width() / 2)) + $(target).scrollLeft(),
 				y = ($(hTarget).height() / 2) - ($(self.root).height() / 2);
 
@@ -76,7 +78,7 @@ jui.defineUI("ui.modal", [ "jquery", "util.base" ], function($, _) {
 			// inner modal일 경우
 			if(tPos != null) {
 				var sh = $(hTarget)[0].scrollHeight;
-				
+
 				h = (sh > h) ? sh : h;
 				y = y + $(hTarget).scrollTop();
 
@@ -86,31 +88,31 @@ jui.defineUI("ui.modal", [ "jquery", "util.base" ], function($, _) {
 
 				h = (h > sh) ? h : sh;
 			}
-			
+
 			return {
 				x: x, y: y, pos: pos, tPos: tPos, w: w, h: h
 			}
 		}
-		
+
 		function createModal(self, w, h) {
 			var mi = self.timestamp;
-			
+
 			if( $modal[mi] != null) return;
-			
-			$modal[mi] = $("<div id='MODAL_" + self.timestamp + "'></div>").css({ 
+
+			$modal[mi] = $("<div id='MODAL_" + self.timestamp + "'></div>").css({
 				position: "absolute",
 				width: w,
 				height: h,
 				left: 0,
 				top: 0,
-				opacity: self.options.opacity, 
+				opacity: self.options.opacity,
 				"background-color": self.options.color,
 				"z-index": (z_index + self.options.index) - 1
 			});
-		
+
 			// 모달 추가
 			$(self.options.target).append($modal[mi]);
-			
+
 			// 루트 모달 옆으로 이동
 			$(self.root).insertAfter($modal[mi]);
 
@@ -119,7 +121,7 @@ jui.defineUI("ui.modal", [ "jquery", "util.base" ], function($, _) {
 				if(self.options.autoHide) {
 					self.hide();
 				}
-				
+
 				return false;
 			});
 		}
@@ -149,15 +151,15 @@ jui.defineUI("ui.modal", [ "jquery", "util.base" ], function($, _) {
 				$clone.remove();
 				$clone = null;
 			}
-			
+
 			$(opts.target).css("position", uiTarget.position);
 			$(this.root).css(uiObj);
-			
+
 			if($modal[mi]) {
 				$modal[mi].remove();
-				delete $modal[mi]; 
+				delete $modal[mi];
 			}
-			
+
 			this.type = "hide";
 		}
 
@@ -246,6 +248,6 @@ jui.defineUI("ui.modal", [ "jquery", "util.base" ], function($, _) {
 			autoHide: true
         }
     }
-	
+
 	return UI;
 });


### PR DESCRIPTION
기존의 modal은 width가 변하는 경우에만 resize를 수행하고, width가 동일한 경우에는 바로 return하여 resize를 수행하지 않았습니다.

창 높이가 변하는 경우에는 resize가 수행되지 않아야 하나, 창 높이가 줄어드는 경우에 한해서만 리사이징이 이루어졌습니다. 창 높이가 줄어들 때는 줄어드는 순간 스크롤바가 생겼다가 사라지면서 width가 변화하여 리사이징이 이루어진 것으로 보입니다. 하지만 창 높이를 늘리는 경우는 resize가 수행되지 않아 아래에 빈 영역이 발생하였습니다.

따라서, 창 높이의 변화도 감지하여 resizing이 될 수 있도록 width 또는 height중 하나라도 변화하는 경우 resize를 수행하도록 하였습니다. 얼떨결에 리사이징이 이루어졌던 창 높이 감소뿐만 아니라 창 높이 증가에도 리사이징이 가능해질 것으로 보입니다.